### PR TITLE
Replace `include` with `(include|import)_tasks`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,10 +17,10 @@
     createhome: false
 
 - name: installing packages with apt
-  include: install.apt.yml
+  include_tasks: install.apt.yml
   when: ansible_os_family == 'Debian'
 
-- include: config.yml
+- import_tasks: config.yml
 
 - name: ensure bind is started
   service:


### PR DESCRIPTION
Allows us to use ansible >2.14, as `include` is removed in later versions
